### PR TITLE
gradle build now passes out-of-the-box on a windows machine with java1.8

### DIFF
--- a/src/main/java/com/vtence/molecule/BodyPart.java
+++ b/src/main/java/com/vtence/molecule/BodyPart.java
@@ -12,7 +12,7 @@ import java.nio.charset.Charset;
 
 /**
  * Represents a body part or form item that was received within a <code>multipart/form-data</code> <code>POST</code> request.
- * <br/>
+ * <br>
  * Typically a part represents either a text parameter or a file.
  * The contents of the part can be acquired either as an <code>InputStream</code>, a byte array or as a
  * string encoded in the encoding specified with the <code>Content-Type</code> header or in <code>UTF-8</code>.
@@ -82,7 +82,7 @@ public class BodyPart {
     }
 
     /**
-     * Consumes the content of this part and returns it as a string.<br/>
+     * Consumes the content of this part and returns it as a string.<br>
      * The encoding of the string is taken from the content type.
      * If no content type is sent the content is decoded in UTF-8.
      *
@@ -94,7 +94,7 @@ public class BodyPart {
     }
 
     /**
-     * Consumes the content of this part and returns it as a byte array. <br/>
+     * Consumes the content of this part and returns it as a byte array. <br>
      *
      * @return the binary representation of the part
      * @throws IOException thrown if the content can not be accessed

--- a/src/main/java/com/vtence/molecule/Request.java
+++ b/src/main/java/com/vtence/molecule/Request.java
@@ -615,7 +615,7 @@ public class Request {
      *
      * @see Request#attribute(Object, Object)
      * @param key the key of the attribute to retrieve
-     * @return <T> the value of the attribute, or null if the attribute does not exist
+     * @return the value of the attribute, or null if the attribute does not exist
      * @throws java.lang.ClassCastException if the attribute value is not an instance of the type parameter
      */
     @SuppressWarnings("unchecked")

--- a/src/test/java/com/vtence/molecule/templating/JMustacheRendererTest.java
+++ b/src/test/java/com/vtence/molecule/templating/JMustacheRendererTest.java
@@ -12,6 +12,8 @@ import static org.hamcrest.Matchers.containsString;
 
 public class JMustacheRendererTest {
 
+    private static final String encodedAe = "\u00E6";
+
     JMustacheRenderer mustache = new JMustacheRenderer().fromDir(locateOnClasspath(("views")));
 
     @Test public void
@@ -45,14 +47,14 @@ public class JMustacheRendererTest {
     @Test public void
     assumesUtf8EncodingByDefault() throws IOException,SAXException {
         String view = render("utf-8").asString(mustache);
-        assertThat("view", view, containsString("ægithales"));
+        assertThat("view", view, containsString(encodedAe + "githales"));
     }
 
     @Test public void
     makesTemplateEncodingConfigurable() throws IOException, SAXException {
         mustache.encoding("utf-16be");
         String view = render("utf-16be").asString(mustache);
-        assertThat("view", view, containsString("ægithales"));
+        assertThat("view", view, containsString(encodedAe + "githales"));
     }
 
     @Test public void

--- a/src/test/java/com/vtence/molecule/templating/JMustacheRendererTest.java
+++ b/src/test/java/com/vtence/molecule/templating/JMustacheRendererTest.java
@@ -12,8 +12,6 @@ import static org.hamcrest.Matchers.containsString;
 
 public class JMustacheRendererTest {
 
-    private static final String encodedAe = "\u00E6";
-
     JMustacheRenderer mustache = new JMustacheRenderer().fromDir(locateOnClasspath(("views")));
 
     @Test public void
@@ -47,14 +45,14 @@ public class JMustacheRendererTest {
     @Test public void
     assumesUtf8EncodingByDefault() throws IOException,SAXException {
         String view = render("utf-8").asString(mustache);
-        assertThat("view", view, containsString(encodedAe + "githales"));
+        assertThat("view", view, containsString("\u00E6githales"));
     }
 
     @Test public void
     makesTemplateEncodingConfigurable() throws IOException, SAXException {
         mustache.encoding("utf-16be");
         String view = render("utf-16be").asString(mustache);
-        assertThat("view", view, containsString(encodedAe + "githales"));
+        assertThat("view", view, containsString("\u00E6githales"));
     }
 
     @Test public void

--- a/src/test/java/examples/multipart/MultipartTest.java
+++ b/src/test/java/examples/multipart/MultipartTest.java
@@ -62,7 +62,7 @@ public class MultipartTest {
         response = request.content(form).post("/profile");
 
         assertThat(response).isOK()
-                            .hasBodyText(containsString("biography: Je suis un méchant minion"));
+                            .hasBodyText(containsString("biography: Je suis un m\u00E9chant minion"));
     }
 
     @Test

--- a/src/test/java/examples/performance/CachingAndCompressionTest.java
+++ b/src/test/java/examples/performance/CachingAndCompressionTest.java
@@ -13,8 +13,10 @@ import java.io.IOException;
 import static com.vtence.molecule.testing.http.HttpResponseAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.core.StringStartsWith.startsWith;
 
 public class CachingAndCompressionTest {
+    String GZIP_HEADER = new String(new char[]{0x1f, 0x8b, 0x08});
     Delorean delorean = new Delorean();
     CachingAndCompressionExample caching = new CachingAndCompressionExample(delorean);
     WebServer server = WebServer.create(9999);
@@ -34,15 +36,11 @@ public class CachingAndCompressionTest {
 
     @Test
     public void compressingResponses() throws IOException {
-        String contentLengthUnderJvm16 = "170";
-        String contentLengthUnderJvm18 = "173";
-
-        response = request.header("Accept-Encoding", "gzip; q=0.9, deflate").get("/");
-
+        response = request.header("Accept-Encoding", "deflate; q=0.9, gzip").get("/");
         assertThat(response).isOK()
-                            // We expect deflate compression, which is preferred by the client
-                            .hasHeader("Content-Encoding", "deflate")
-                            .hasHeader("Content-Length", anyOf(equalTo(contentLengthUnderJvm16), equalTo(contentLengthUnderJvm18)));
+                // We expect gzip compression, which is preferred by the client
+                .hasHeader("Content-Encoding", "gzip")
+                .hasBodyText(startsWith(GZIP_HEADER));
     }
 
     @Test

--- a/src/test/java/examples/performance/CachingAndCompressionTest.java
+++ b/src/test/java/examples/performance/CachingAndCompressionTest.java
@@ -11,6 +11,8 @@ import org.junit.Test;
 import java.io.IOException;
 
 import static com.vtence.molecule.testing.http.HttpResponseAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
 
 public class CachingAndCompressionTest {
     Delorean delorean = new Delorean();
@@ -32,12 +34,15 @@ public class CachingAndCompressionTest {
 
     @Test
     public void compressingResponses() throws IOException {
+        String contentLengthUnderJvm16 = "170";
+        String contentLengthUnderJvm18 = "173";
+
         response = request.header("Accept-Encoding", "gzip; q=0.9, deflate").get("/");
 
         assertThat(response).isOK()
                             // We expect deflate compression, which is preferred by the client
                             .hasHeader("Content-Encoding", "deflate")
-                            .hasHeader("Content-Length", "170");
+                            .hasHeader("Content-Length", anyOf(equalTo(contentLengthUnderJvm16), equalTo(contentLengthUnderJvm18)));
     }
 
     @Test


### PR DESCRIPTION
Made the minimal fixes so that ``gradle build`` completes successfully on my windows 8.1 machine with jvm 1.8.40 installed.

The fixes were mostly simple:
* javadoc fixes
* unicode-escape the utf-8 chars (the windows console is not utf-8)
* change the expected content-length of a gzipped-response (my assumption is that this is due to changes to the implementation of the gzipstream classes in jdk1.8, but it could be due to Windows specificity too, such as new line characters)

I am open to any and all feedback.
Thanks!