### PR TITLE
Failsafe middleware now renders the entire chain of error & cause

### DIFF
--- a/src/main/java/com/vtence/molecule/middlewares/Failsafe.java
+++ b/src/main/java/com/vtence/molecule/middlewares/Failsafe.java
@@ -33,15 +33,27 @@ public class Failsafe extends AbstractMiddleware {
         PrintWriter buffer = new PrintWriter(html);
         buffer.println("<h1>Oups!</h1>");
         buffer.println("<h2>Sorry, an internal error occurred</h2>");
+        startPrintingError(buffer, error);
+
+        return html.toString();
+    }
+
+    private void startPrintingError(PrintWriter buffer, Throwable error) {
+        printErrorAndCause(buffer, error, false);
+    }
+
+    private void printErrorAndCause(PrintWriter buffer, Throwable error, boolean addCausedBy) {
         buffer.println("<p>");
-        buffer.println("  <strong>" + error.toString() + "</strong>");
+        buffer.printf("  <strong>%s%s</strong>", addCausedBy ? "Caused by: " : "", error).println();
         buffer.println("  <ul>");
         for (StackTraceElement stackTraceElement : error.getStackTrace()) {
             buffer.println("    <li>" + stackTraceElement.toString() + "</li>");
         }
         buffer.println("  </ul>");
         buffer.println("</p>");
-
-        return html.toString();
+        if (error.getCause() != null) {
+            buffer.println();
+            printErrorAndCause(buffer, error.getCause(), true);
+        }
     }
 }

--- a/src/main/java/com/vtence/molecule/session/PeriodicSessionHouseKeeping.java
+++ b/src/main/java/com/vtence/molecule/session/PeriodicSessionHouseKeeping.java
@@ -16,7 +16,7 @@ public class PeriodicSessionHouseKeeping {
     private final SessionHouse sessions;
 
     private long choresInterval;
-    private ScheduledFuture chores;
+    private ScheduledFuture<?> chores;
 
     public PeriodicSessionHouseKeeping(ScheduledExecutorService scheduler, SessionHouse sessions) {
         this(scheduler, sessions, EVERY_HOUR, SECONDS);

--- a/src/test/java/com/vtence/molecule/middlewares/FailsafeTest.java
+++ b/src/test/java/com/vtence/molecule/middlewares/FailsafeTest.java
@@ -9,29 +9,20 @@ import org.junit.Test;
 import static com.vtence.molecule.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static com.vtence.molecule.testing.ResponseAssert.assertThat;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.not;
 
 public class FailsafeTest {
     Failsafe failsafe = new Failsafe();
 
     String errorMessage = "An error occurred!";
-    Error error = new Error(errorMessage) {{
-        setStackTrace(new StackTraceElement[] {
-                      new StackTraceElement("stack", "trace", "line", 1),
-                      new StackTraceElement("stack", "trace", "line", 2)
-        });
-    }};
+    Error error = newError(errorMessage);
 
     Request request = new Request();
     Response response = new Response();
 
     @Before public void
     handleRequest() throws Exception {
-        failsafe.connectTo(new Application() {
-            public void handle(Request request, Response response) throws Exception {
-                throw error;
-            }
-        });
-        failsafe.handle(request, response);
+        putErrorInResponse(failsafe, error);
     }
 
     @Test public void
@@ -40,14 +31,61 @@ public class FailsafeTest {
     }
 
     @Test public void
-    rendersErrorTemplate() {
+    rendersTheError() {
         assertThat(response).hasBodyText(containsString(errorMessage))
-                            .hasBodyText(containsString("stack.trace(line:1)"))
-                            .hasBodyText(containsString("stack.trace(line:2)"));
+                .hasBodyText(containsString("stack.trace(line:1)"))
+                .hasBodyText(containsString("stack.trace(line:2)"))
+                .hasBodyText(not(containsString("Caused by:")));
+    }
+
+    @Test public void
+    rendersTheCausesWhenThereAreSome() throws Exception {
+        Error causeOfCause = newError("cause of cause", null, stackFrame("cause.of.cause.stack", 1));
+        Error cause = newError("cause of error", causeOfCause, stackFrame("cause.of.error.stack", 1));
+        Error errorWithCause = newError("this error has a cause", cause);
+
+        putErrorInResponse(failsafe, errorWithCause);
+
+        assertThat(response).hasBodyText(containsString("Caused by: java.lang.Error: cause of error"))
+                .hasBodyText(containsString("cause.of.error.stack.trace(line:1)"))
+                .hasBodyText(containsString("Caused by: java.lang.Error: cause of cause"))
+                .hasBodyText(containsString("cause.of.cause.stack.trace(line:1)"));
     }
 
     @Test public void
     respondsWithHtmlContentUtf8Encoded() {
         assertThat(response).hasContentType("text/html; charset=utf-8");
+    }
+
+    private void
+    putErrorInResponse(final Failsafe failsafe, final Error error) throws Exception {
+        failsafe.connectTo(new Application() {
+            public void handle(Request request, Response response) throws Exception {
+                throw error;
+            }
+        });
+        failsafe.handle(request, response);
+    }
+
+    private Error
+    newError(String errorMessage) {
+        return newError(errorMessage, null);
+    }
+
+    private Error
+    newError(String errorMessage, Error cause) {
+        return newError(errorMessage, cause, stackFrame("stack", 1), stackFrame("stack", 2));
+    }
+
+    private Error
+    newError(String errorMessage, Error cause, StackTraceElement... stackTrace) {
+        Error error = new Error(errorMessage, cause);
+        error.setStackTrace(stackTrace);
+        return error;
+    }
+
+    private StackTraceElement
+    stackFrame(String className, int lineNumber) {
+        return new StackTraceElement(className, "trace", "line", lineNumber);
     }
 }


### PR DESCRIPTION
Having the full exception information when users or support sends us the stack trace is really appreciated (removes the need for us to go in the log to check.)

Unrelated to this feature, but in the same PR: a minor raw type compiler warning fix.