### PR TITLE
expose the number of threads in the pool of the ContainerSocketProcessor

### DIFF
--- a/src/main/java/com/vtence/molecule/servers/SimpleServer.java
+++ b/src/main/java/com/vtence/molecule/servers/SimpleServer.java
@@ -20,15 +20,23 @@ import java.util.List;
 
 public class SimpleServer implements Server {
 
+    private static final int DEFAULT_NUMBER_OF_THREADS = 8;
+
     private final String host;
     private final int port;
+    private final int numberOfThreads;
 
     private FailureReporter failureReporter = FailureReporter.IGNORE;
     private Connection connection;
 
     public SimpleServer(String host, int port) {
+        this(host, port, DEFAULT_NUMBER_OF_THREADS);
+    }
+
+    public SimpleServer(String host, int port, int numberOfThreads) {
         this.host = host;
         this.port = port;
+        this.numberOfThreads = numberOfThreads;
     }
 
     public void reportErrorsTo(FailureReporter reporter) {
@@ -48,7 +56,7 @@ public class SimpleServer implements Server {
     }
 
     public void run(final Application app, SSLContext context) throws IOException {
-        connection = new SocketConnection(new ContainerSocketProcessor(new ApplicationContainer(app)));
+        connection = new SocketConnection(new ContainerSocketProcessor(new ApplicationContainer(app), numberOfThreads));
         connection.connect(new InetSocketAddress(host, port), context);
     }
 


### PR DESCRIPTION
Our load tests revealed that the default number of threads of the pool (8) was to small for our needs and cause slooooooow response time from the server.  We now simply expose that property in the constructor of SimpleServer.  

Our intention is to do something like: 
`new WebServer(new SimpleServer(host, port, 100));`

