### PR TITLE
Added support logging in the Apache Combined Format

### DIFF
--- a/src/main/java/com/vtence/molecule/middlewares/ApacheCombinedFormatLogger.java
+++ b/src/main/java/com/vtence/molecule/middlewares/ApacheCombinedFormatLogger.java
@@ -1,0 +1,39 @@
+package com.vtence.molecule.middlewares;
+
+import com.vtence.molecule.Request;
+import com.vtence.molecule.Response;
+import com.vtence.molecule.http.HeaderNames;
+
+import java.time.Clock;
+import java.util.Locale;
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+
+public class ApacheCombinedFormatLogger extends ApacheLogger {
+    private static final String COMBINED_LOG_FORMAT = "%s - - [%s] \"%s %s %s\" %s %s \"%s\" \"%s\"";
+
+    public ApacheCombinedFormatLogger(Logger logger) {
+        super(logger, Clock.systemDefaultZone());
+    }
+
+    public ApacheCombinedFormatLogger(Logger logger, Clock clock, Locale locale) {
+        super(logger, clock, locale);
+    }
+
+    @Override
+    protected Consumer<Response> logAccess(Request request) {
+        return response -> {
+            String msg = String.format(COMBINED_LOG_FORMAT,
+                    request.remoteIp(),
+                    currentTime(),
+                    request.method(),
+                    request.uri(),
+                    request.protocol(),
+                    response.statusCode(),
+                    contentLengthOf(response),
+                    nullToEmpty(request.header(HeaderNames.REFERER)),
+                    nullToEmpty(request.header(HeaderNames.USER_AGENT)));
+            logger.info(msg);
+        };
+    }
+}

--- a/src/main/java/com/vtence/molecule/middlewares/ApacheCommonLogger.java
+++ b/src/main/java/com/vtence/molecule/middlewares/ApacheCommonLogger.java
@@ -5,40 +5,23 @@ import com.vtence.molecule.Response;
 import com.vtence.molecule.http.HttpMethod;
 
 import java.time.Clock;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 
-public class ApacheCommonLogger extends AbstractMiddleware {
-
+public class ApacheCommonLogger extends ApacheLogger {
     private static final String COMMON_LOG_FORMAT = "%s - %s [%s] \"%s %s %s\" %s %s";
-    private static final String DATE_FORMAT = "dd/MMM/yyyy:HH:mm:ss Z";
-
-    private final Logger logger;
-    private final Clock clock;
-    private final DateTimeFormatter formatter;
 
     public ApacheCommonLogger(Logger logger) {
-        this(logger, Clock.systemDefaultZone());
-    }
-
-    public ApacheCommonLogger(Logger logger, Clock clock) {
-        this(logger, clock, Locale.getDefault());
+        super(logger, Clock.systemDefaultZone());
     }
 
     public ApacheCommonLogger(Logger logger, Clock clock, Locale locale) {
-        this.logger = logger;
-        this.clock = clock;
-        this.formatter = DateTimeFormatter.ofPattern(DATE_FORMAT, locale).withZone(clock.getZone());
+        super(logger, clock, locale);
     }
 
-    public void handle(Request request, Response response) throws Exception {
-        forward(request, response).whenSuccessful(logAccess(request));
-    }
-
-    private Consumer<Response> logAccess(Request request) {
+    @Override
+    protected Consumer<Response> logAccess(Request request) {
         String remoteIp = request.remoteIp();
         HttpMethod method = request.method();
         String uri = request.uri();
@@ -56,13 +39,5 @@ public class ApacheCommonLogger extends AbstractMiddleware {
                     contentLengthOf(response));
             logger.info(msg);
         };
-    }
-
-    private String currentTime() {
-        return ZonedDateTime.now(clock).format(formatter);
-    }
-
-    private Object contentLengthOf(Response response) {
-        return response.size() > 0 ? response.size() : "-";
     }
 }

--- a/src/main/java/com/vtence/molecule/middlewares/ApacheLogger.java
+++ b/src/main/java/com/vtence/molecule/middlewares/ApacheLogger.java
@@ -1,0 +1,49 @@
+package com.vtence.molecule.middlewares;
+
+import com.vtence.molecule.Request;
+import com.vtence.molecule.Response;
+
+import java.time.Clock;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+
+public abstract class ApacheLogger extends AbstractMiddleware {
+    private static final String DATE_FORMAT = "dd/MMM/yyyy:HH:mm:ss Z";
+
+    protected final Logger logger;
+    private final Clock clock;
+    private final DateTimeFormatter formatter;
+
+    protected ApacheLogger(Logger logger, Clock clock) {
+        this(logger, clock, Locale.getDefault());
+    }
+
+    protected ApacheLogger(Logger logger, Clock clock, Locale locale) {
+        this.logger = logger;
+        this.clock = clock;
+        this.formatter = DateTimeFormatter.ofPattern(DATE_FORMAT, locale).withZone(clock.getZone());
+    }
+
+    @Override
+    public void handle(Request request, Response response) throws Exception {
+        forward(request, response).whenSuccessful(logAccess(request));
+    }
+
+    protected abstract Consumer<Response> logAccess(Request request);
+
+    protected String nullToEmpty(String string) {
+        return (string == null) ? "" : string;
+    }
+
+    protected String currentTime() {
+        return ZonedDateTime.now(clock).format(formatter);
+    }
+
+    protected Object contentLengthOf(Response response) {
+        return response.size() > 0 ? response.size() : "-";
+    }
+
+}

--- a/src/test/java/com/vtence/molecule/middlewares/ApacheCombinedFormatLoggerTest.java
+++ b/src/test/java/com/vtence/molecule/middlewares/ApacheCombinedFormatLoggerTest.java
@@ -1,0 +1,73 @@
+package com.vtence.molecule.middlewares;
+
+import com.vtence.molecule.Request;
+import com.vtence.molecule.Response;
+import com.vtence.molecule.http.HeaderNames;
+import com.vtence.molecule.support.LoggingSupport.LogRecordingHandler;
+import org.junit.Test;
+
+import java.time.*;
+import java.util.Locale;
+
+import static com.vtence.molecule.http.HttpMethod.GET;
+import static com.vtence.molecule.http.HttpStatus.OK;
+import static com.vtence.molecule.support.LoggingSupport.anonymousLogger;
+import static org.hamcrest.Matchers.contains;
+
+
+public class ApacheCombinedFormatLoggerTest {
+    LogRecordingHandler logRecords = new LogRecordingHandler();
+    Instant currentTime = LocalDateTime.of(2012, 6, 27, 12, 4, 0).toInstant(ZoneOffset.of("-05:00"));
+    ApacheCombinedFormatLogger apacheCommonLogger = new ApacheCombinedFormatLogger(anonymousLogger(logRecords), Clock.fixed(currentTime, ZoneId.of("GMT+01:00")), Locale.US);
+
+    Request request = new Request().protocol("HTTP/1.1").remoteIp("192.168.0.1");
+    Response response = new Response();
+
+    @Test
+    public void
+    logsRequestsServedInApacheCombinedLogFormat() throws Exception {
+        request
+            .method(GET)
+            .uri("/products?keyword=dogs")
+            .addHeader(HeaderNames.REFERER, "http://lama/wool")
+            .addHeader(HeaderNames.USER_AGENT, "Mozilla/5.0 (compatible; MSIE 9.0; AOL 9.7)");
+
+        apacheCommonLogger.handle(request, response);
+        response.status(OK).body("a response with a size of 28").done();
+
+        response.await();
+        logRecords.assertEntries(contains("192.168.0.1 - - [27/Jun/2012:18:04:00 +0100] \"GET /products?keyword=dogs HTTP/1.1\" 200 28 \"http://lama/wool\" \"Mozilla/5.0 (compatible; MSIE 9.0; AOL 9.7)\""));
+    }
+
+    @Test
+    public void
+    logsEmptyStringWhenNoUserAgentInRequest() throws Exception {
+        request
+                .method(GET)
+                .uri("/products?keyword=dogs")
+                .addHeader(HeaderNames.REFERER, "http://lama/wool");
+
+        apacheCommonLogger.handle(request, response);
+        response.status(OK).body("a response with a size of 28").done();
+
+        response.await();
+        logRecords.assertEntries(contains("192.168.0.1 - - [27/Jun/2012:18:04:00 +0100] \"GET /products?keyword=dogs HTTP/1.1\" 200 28 \"http://lama/wool\" \"\""));
+    }
+
+    @Test
+    public void
+    logsEmptyStringWhenNoRefererInRequest() throws Exception {
+        request
+                .method(GET)
+                .uri("/products?keyword=dogs")
+                .addHeader(HeaderNames.USER_AGENT, "Mozilla/5.0 (compatible; MSIE 9.0; AOL 9.7)");
+
+        apacheCommonLogger.handle(request, response);
+        response.status(OK).body("a response with a size of 28").done();
+
+        response.await();
+        logRecords.assertEntries(contains("192.168.0.1 - - [27/Jun/2012:18:04:00 +0100] \"GET /products?keyword=dogs HTTP/1.1\" 200 28 \"\" \"Mozilla/5.0 (compatible; MSIE 9.0; AOL 9.7)\""));
+    }
+
+
+}

--- a/src/test/java/com/vtence/molecule/middlewares/ApacheCommonLoggerTest.java
+++ b/src/test/java/com/vtence/molecule/middlewares/ApacheCommonLoggerTest.java
@@ -2,30 +2,18 @@ package com.vtence.molecule.middlewares;
 
 import com.vtence.molecule.Request;
 import com.vtence.molecule.Response;
-import org.hamcrest.Matcher;
+import com.vtence.molecule.support.LoggingSupport.LogRecordingHandler;
 import org.junit.Test;
 
-import java.time.Clock;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.util.ArrayList;
-import java.util.List;
+import java.time.*;
 import java.util.Locale;
-import java.util.logging.Handler;
-import java.util.logging.LogRecord;
-import java.util.logging.Logger;
 
-import static com.vtence.molecule.http.HttpMethod.DELETE;
-import static com.vtence.molecule.http.HttpMethod.GET;
-import static com.vtence.molecule.http.HttpMethod.POST;
+import static com.vtence.molecule.http.HttpMethod.*;
 import static com.vtence.molecule.http.HttpStatus.NO_CONTENT;
 import static com.vtence.molecule.http.HttpStatus.OK;
-import static java.util.stream.Collectors.toList;
+import static com.vtence.molecule.support.LoggingSupport.anonymousLogger;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertThat;
 
 public class ApacheCommonLoggerTest {
     LogRecordingHandler logRecords = new LogRecordingHandler();
@@ -73,35 +61,4 @@ public class ApacheCommonLoggerTest {
         logRecords.assertEntries(contains(containsString("\"DELETE /logout HTTP/1.1\" 204 -")));
     }
 
-    private Logger anonymousLogger(Handler handler) {
-        Logger logger = Logger.getAnonymousLogger();
-        logger.setUseParentHandlers(false);
-        logger.addHandler(handler);
-        return logger;
-    }
-
-    public static class LogRecordingHandler extends Handler {
-        private final List<LogRecord> records = new ArrayList<>();
-
-        @Override
-        public void publish(LogRecord record) {
-            records.add(record);
-        }
-
-        @Override
-        public void flush() {
-        }
-
-        @Override
-        public void close() throws SecurityException {
-        }
-
-        public List<String> messages() {
-            return records.stream().map(LogRecord::getMessage).collect(toList());
-        }
-
-        public void assertEntries(Matcher<? super List<String>> matching) {
-            assertThat("log messages", messages(), matching);
-        }
-    }
 }

--- a/src/test/java/com/vtence/molecule/support/LoggingSupport.java
+++ b/src/test/java/com/vtence/molecule/support/LoggingSupport.java
@@ -1,0 +1,48 @@
+package com.vtence.molecule.support;
+
+import org.hamcrest.Matcher;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertThat;
+
+public class LoggingSupport {
+
+    public static Logger anonymousLogger(Handler handler) {
+        Logger logger = Logger.getAnonymousLogger();
+        logger.setUseParentHandlers(false);
+        logger.addHandler(handler);
+        return logger;
+    }
+
+    public static class LogRecordingHandler extends Handler {
+        private final List<LogRecord> records = new ArrayList<>();
+
+        @Override
+        public void publish(LogRecord record) {
+            records.add(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() throws SecurityException {
+        }
+
+        public List<String> messages() {
+            return records.stream().map(LogRecord::getMessage).collect(toList());
+        }
+
+        public void assertEntries(Matcher<? super List<String>> matching) {
+            assertThat("log messages", messages(), matching);
+        }
+    }
+
+}


### PR DESCRIPTION
Needed to support logging the user agent and referrer. The format is documented here : http://httpd.apache.org/docs/1.3/logs.html#combined.

Note: The spec doesn't specifiy what to do if the user agent or referer headers are empty. For now, we've left an empty string.