### PR TITLE
Multiple cookies are now output as distinct Set-Cookie headers instead of being folded

### DIFF
--- a/src/main/java/com/vtence/molecule/Response.java
+++ b/src/main/java/com/vtence/molecule/Response.java
@@ -2,11 +2,13 @@ package com.vtence.molecule;
 
 import com.vtence.molecule.helpers.Headers;
 import com.vtence.molecule.http.ContentType;
+import com.vtence.molecule.http.Cookie;
 import com.vtence.molecule.http.HttpStatus;
 import com.vtence.molecule.lib.BinaryBody;
 
 import java.nio.charset.Charset;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -34,6 +36,7 @@ import static java.nio.charset.StandardCharsets.ISO_8859_1;
 public class Response {
     private final CompletableFuture<Response> done = new CompletableFuture<>();
     private final Headers headers = new Headers();
+    private final List<Cookie> cookies = new ArrayList<>();
 
     private CompletableFuture<Response> postProcessing = done;
     private int statusCode = HttpStatus.OK.code;
@@ -246,6 +249,24 @@ public class Response {
     public Response removeHeader(String name) {
         headers.remove(name);
         return this;
+    }
+
+    /**
+     * Adds a cookie to the response.
+     *
+     * @param cookie the cookie to add to the response
+     */
+    public Response addCookie(Cookie cookie) {
+        cookies.add(cookie);
+        return this;
+    }
+
+    /**
+     * Gets the list of cookies for this response
+     * @return the (possibly empty) list of cookies
+     */
+    public List<Cookie> cookies() {
+        return new ArrayList<>(cookies);
     }
 
     /**

--- a/src/main/java/com/vtence/molecule/middlewares/Cookies.java
+++ b/src/main/java/com/vtence/molecule/middlewares/Cookies.java
@@ -32,11 +32,11 @@ public class Cookies extends AbstractMiddleware {
     private Consumer<Response> commitCookies(CookieJar cookies) {
         return response -> {
             for (Cookie cookie : cookies.fresh()) {
-                response.addHeader(SET_COOKIE, cookie.toString());
+                response.addCookie(cookie);
             }
 
             for (Cookie cookie : cookies.discarded()) {
-                response.addHeader(SET_COOKIE, cookie.maxAge(0).toString());
+                response.addCookie(cookie.maxAge(0));
             }
         };
     }

--- a/src/main/java/com/vtence/molecule/servers/SimpleServer.java
+++ b/src/main/java/com/vtence/molecule/servers/SimpleServer.java
@@ -1,7 +1,10 @@
 package com.vtence.molecule.servers;
 
 import com.vtence.molecule.*;
-import org.simpleframework.http.Part;
+import com.vtence.molecule.Request;
+import com.vtence.molecule.Response;
+import com.vtence.molecule.http.Cookie;
+import org.simpleframework.http.*;
 import org.simpleframework.http.core.Container;
 import org.simpleframework.http.core.ContainerSocketProcessor;
 import org.simpleframework.transport.connect.Connection;
@@ -154,6 +157,7 @@ public class SimpleServer implements Server {
         private void commit(org.simpleframework.http.Response simple, Response response) throws IOException {
             setStatusLine(simple, response);
             setHeaders(simple, response);
+            setCookies(simple, response);
             writeBody(simple, response);
         }
 
@@ -165,6 +169,19 @@ public class SimpleServer implements Server {
         private void setHeaders(org.simpleframework.http.Response simple, Response response) {
             for (String name : response.headerNames()) {
                 simple.setValue(name, response.header(name));
+            }
+        }
+
+        private void setCookies(org.simpleframework.http.Response simple, Response response) {
+            for (Cookie cookie : response.cookies()) {
+                org.simpleframework.http.Cookie simpleCookie = new org.simpleframework.http.Cookie(cookie.name(), cookie.value());
+                simpleCookie.setDomain(cookie.domain());
+                simpleCookie.setExpiry(cookie.maxAge() + 1);
+                simpleCookie.setPath(cookie.path());
+                simpleCookie.setProtected(cookie.httpOnly());
+                simpleCookie.setSecure(cookie.secure());
+                simpleCookie.setVersion(cookie.version());
+                simple.setCookie(simpleCookie);
             }
         }
 

--- a/src/test/java/com/vtence/molecule/middlewares/CookiesTest.java
+++ b/src/test/java/com/vtence/molecule/middlewares/CookiesTest.java
@@ -51,8 +51,8 @@ public class CookiesTest {
         response.done();
 
         assertNoExecutionError();
-        assertThat(response).hasHeaders("Set-Cookie",
-                contains("oogle=foogle; version=1; path=/", "gorp=mumble; version=1; path=/"));
+        assertThat(response).hasCookies(contains("oogle=foogle; version=1; path=/", "gorp=mumble; version=1; path=/"));
+        assertThat(response).hasNoHeader("Set-Cookie");
     }
 
     @Test
@@ -67,7 +67,8 @@ public class CookiesTest {
         response.done();
 
         assertNoExecutionError();
-        assertThat(response).hasHeaders("Set-Cookie", contains("foo=; version=1; path=/; max-age=0"));
+        assertThat(response).hasCookies(contains("foo=; version=1; path=/; max-age=0"));
+        assertThat(response).hasNoHeader("Set-Cookie");
     }
 
     @Test

--- a/src/test/java/com/vtence/molecule/testing/ResponseAssert.java
+++ b/src/test/java/com/vtence/molecule/testing/ResponseAssert.java
@@ -1,12 +1,14 @@
 package com.vtence.molecule.testing;
 
 import com.vtence.molecule.Response;
+import com.vtence.molecule.http.Cookie;
 import com.vtence.molecule.http.HeaderNames;
 import com.vtence.molecule.http.HttpStatus;
 import org.hamcrest.Matcher;
 import org.junit.Assert;
 
 import java.nio.charset.Charset;
+import java.util.stream.Collectors;
 
 import static com.vtence.molecule.http.HeaderNames.CONTENT_TYPE;
 import static com.vtence.molecule.testing.CharsetDetector.detectCharsetOf;
@@ -136,6 +138,11 @@ public class ResponseAssert {
 
     public ResponseAssert isDone() {
         Assert.assertThat("response completed", response.isDone(), is(true));
+        return this;
+    }
+
+    public ResponseAssert hasCookies(Matcher<Iterable<? extends String>> matchingValues) {
+        Assert.assertThat("response cookies", response.cookies().stream().map(Cookie::toString).collect(Collectors.toList()), matchingValues);
         return this;
     }
 }

--- a/src/test/java/examples/session/SessionTest.java
+++ b/src/test/java/examples/session/SessionTest.java
@@ -68,7 +68,7 @@ public class SessionTest {
     public void creatingATransientSessionCookie() throws IOException {
         response = request.content(new UrlEncodedForm().addField("username", "Vincent")).post("/login");
         assertNoError();
-        assertThat(response).hasCookie(SESSION_COOKIE).hasMaxAge(-1);
+        assertThat(response).hasCookie(SESSION_COOKIE).hasMaxAge(0);
     }
 
     @Test


### PR DESCRIPTION
As [rfc6265](https://tools.ietf.org/html/rfc6265), section 3 - last paragraph, recommends: multiple cookies are now output in the response as multiple Set-Cookie header lines instead of being folded into one line, like molecule did previously.

This was causing grief on our side due to us outputting 2 cookies and having Chrome (our user-agent) only read the first.

Points we feel need to be discussed in this PR:
* We were not able to have a end-to-end test that confirms that 2 distinct Set-Cookie headers were output by the server (the `UrlConnection` parses headers and does not let us inspect the raw header section.
* We feel that adding `addCookie()/cookies()` on the `Response` object dilutes the importance of the `CookieJar`. i.e. a beginner could start adding and removing cookies through the `Response` object and never benefit from the `Cookies` middleware auto-management.