### PR TITLE
Multiple cookies are now output as distinct Set-Cookie headers instead of being folded

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,8 @@ dependencies {
   testCompile libs.juniversal_chardet
 }
 
+compileJava.options.encoding = 'UTF-8'
+
 task 'version' << {
   println version
 }

--- a/src/main/java/com/vtence/molecule/servers/SimpleServer.java
+++ b/src/main/java/com/vtence/molecule/servers/SimpleServer.java
@@ -164,7 +164,9 @@ public class SimpleServer implements Server {
 
         private void setHeaders(org.simpleframework.http.Response simple, Response response) {
             for (String name : response.headerNames()) {
-                simple.setValue(name, response.header(name));
+                for (String value: response.headers(name)) {
+                    simple.addValue(name, value);
+                }
             }
         }
 

--- a/src/test/java/com/vtence/molecule/servers/SimpleServerTest.java
+++ b/src/test/java/com/vtence/molecule/servers/SimpleServerTest.java
@@ -192,6 +192,20 @@ public class SimpleServerTest {
                 contains("gzip", "identity; q=0.5", "deflate;q=1.0", "*;q=0"));
     }
 
+    @Test public void
+    writesHeadersWithMultipleValues() throws IOException {
+        server.run((request, response) -> {
+            response.addHeader("Cache-Control", "no-cache");
+            response.addHeader("Cache-Control", "no-store");
+            response.done();
+        });
+
+        response = request.send();
+
+        assertNoError();
+        assertThat("response headers", response.headers("Cache-Control"), hasItems("no-cache", "no-store"));
+    }
+
     @SuppressWarnings("unchecked")
     @Test public void
     detailsRequestContent() throws IOException {


### PR DESCRIPTION
This accomplishes the same as #45, except with less changes to `Response` object.
It is made according to the last suggestions you made: use `addValue()`.

We added a weak test that validates that repeated headers are sent over the wire, but we were not able to assert the actual serialization format (one header with a comma-separated list or 2 header lines with one value each.

Even though, this seemed good enough.

What do you think?

Note: the UTF-8 charset is also explicitly set in build.gradle, this removes errors on Windows.